### PR TITLE
Configuration-based filtering of (assembly) files to be scanned by WebActivator

### DIFF
--- a/WebActivator/ActivationManager.cs
+++ b/WebActivator/ActivationManager.cs
@@ -16,6 +16,7 @@ namespace WebActivatorEx
     {
         private static bool _hasInited;
         private static List<Assembly> _assemblies;
+        private static Func<Assembly, bool> _assemblyFilter = a => true; 
 
         // For unit test purpose
         public static void Reset()
@@ -137,10 +138,21 @@ namespace WebActivatorEx
             RunActivationMethods<ApplicationShutdownMethodAttribute>();
         }
 
+        public static void SetAssemblyFilter(Func<Assembly, bool> filter)
+        {
+            if (filter == null)
+            {
+                throw new ArgumentNullException("filter");
+            }
+
+            _assemblyFilter = filter;
+        }
+
         // Call the relevant activation method from all assemblies
         private static void RunActivationMethods<T>(bool designerMode = false) where T : BaseActivationMethodAttribute
         {
             var attribs = Assemblies.Concat(AppCodeAssemblies)
+                                    .Where(assembly => _assemblyFilter(assembly))
                                     .SelectMany(assembly => assembly.GetActivationAttributes<T>())
                                     .OrderBy(att => att.Order);
 

--- a/WebActivatorTest/App.config
+++ b/WebActivatorTest/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <!-- This example excludes
+           * Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll (set to Copy Local just for these tests)
+           * System assemblies (set to Copy Local for the tests)
+           * WebActivator itself
+    -->
+    <add key="webactivator:excludedFilesExpression" value="bin\\Debug\\(WebActivator|System|Microsoft).*" />
+  </appSettings>
+</configuration>

--- a/WebActivatorTest/WebActivatorTest.csproj
+++ b/WebActivatorTest/WebActivatorTest.csproj
@@ -35,10 +35,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="System" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -63,6 +68,9 @@
       <Project>{339C42C9-C961-4E37-B64E-16F1EF03E4D9}</Project>
       <Name>WebActivator</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />

--- a/WebActivatorTest/WebActivatorUnitTest.cs
+++ b/WebActivatorTest/WebActivatorUnitTest.cs
@@ -30,6 +30,21 @@ namespace WebActivatorTest
             Assert.IsTrue(TestLibrary.MyStartupCode.StartCalled);
             Assert.IsTrue(TestLibrary.MyStartupCode.Start2Called);
             Assert.IsTrue(TestLibrary.MyStartupCode.CallMeAfterAppStartCalled);
+            Assert.IsTrue(TestLibrary2.MyOtherStartupCode.StartCalled);
+            Assert.IsTrue(TestLibrary2.MyOtherStartupCode.Start2Called);
+        }
+
+        [TestMethod]
+        public void TestTestLibrary2IsNotScanned()
+        {
+            ActivationManager.SetAssemblyFilter(a => !a.FullName.Contains("TestLibrary2"));
+            ActivationManager.Run();
+
+            Assert.IsTrue(TestLibrary.MyStartupCode.StartCalled);
+            Assert.IsTrue(TestLibrary.MyStartupCode.Start2Called);
+            Assert.IsTrue(TestLibrary.MyStartupCode.CallMeAfterAppStartCalled);
+            Assert.IsFalse(TestLibrary2.MyOtherStartupCode.StartCalled);
+            Assert.IsFalse(TestLibrary2.MyOtherStartupCode.Start2Called);
         }
 
         [TestMethod]

--- a/WebActivatorTest/WebActivatorUnitTest.cs
+++ b/WebActivatorTest/WebActivatorUnitTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestLibrary;
 using TestLibrary2;
 using WebActivatorEx;
@@ -35,16 +38,18 @@ namespace WebActivatorTest
         }
 
         [TestMethod]
-        public void TestTestLibrary2IsNotScanned()
+        public void TestSystemMicrosoftAndWebActivatorAssembliesAreIgnored()
         {
-            ActivationManager.SetAssemblyFilter(a => !a.FullName.Contains("TestLibrary2"));
             ActivationManager.Run();
 
-            Assert.IsTrue(TestLibrary.MyStartupCode.StartCalled);
-            Assert.IsTrue(TestLibrary.MyStartupCode.Start2Called);
-            Assert.IsTrue(TestLibrary.MyStartupCode.CallMeAfterAppStartCalled);
-            Assert.IsFalse(TestLibrary2.MyOtherStartupCode.StartCalled);
-            Assert.IsFalse(TestLibrary2.MyOtherStartupCode.Start2Called);
+            // we're using reflection here to avoid changing the API just for the test
+            var assemblies = (List<Assembly>)typeof(ActivationManager)
+                .GetField("_assemblies", BindingFlags.Static | BindingFlags.NonPublic)
+                .GetValue(null);
+
+            Assert.IsFalse(assemblies.Any(a => a.GetName().Name.StartsWith("System")));
+            Assert.IsFalse(assemblies.Any(a => a.GetName().Name.StartsWith("Microsoft")));
+            Assert.IsFalse(assemblies.Any(a => a.GetName().Name.StartsWith("WebActivator")));
         }
 
         [TestMethod]


### PR DESCRIPTION
Here's the [change we discussed](https://github.com/davidebbo/WebActivator/issues/28). A single regex with `|`s in it seems to suffice for a list of assemblies. See the `app.config` of the test project for an example.