### PR TITLE
Searches all subdirectories in the bin folder when compiling list of assemblies

### DIFF
--- a/WebActivator/ActivationManager.cs
+++ b/WebActivator/ActivationManager.cs
@@ -131,7 +131,7 @@ namespace WebActivatorEx
             string directory = HostingEnvironment.IsHosted
                 ? HttpRuntime.BinDirectory
                 : Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-            return Directory.GetFiles(directory, "*.dll");
+            return Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories);
         }
 
         // Return all the App_Code assemblies


### PR DESCRIPTION
This partially addresses closed issue #21; there are likely better ways of handling this, but this would be a quick fix.